### PR TITLE
Валидация похожести имени/фамилии с паролей, начиная с 7 символов

### DIFF
--- a/backend/aggcarshering/settings.py
+++ b/backend/aggcarshering/settings.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 import os
 from pathlib import Path
 
@@ -116,6 +117,17 @@ else:
 AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+        "OPTIONS": {
+            "user_attributes": ['first_name'],
+            "max_similarity": 0.7,  # Максимальная схожесть для first_name
+        },
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+        "OPTIONS": {
+            "user_attributes": ['last_name'],
+            "max_similarity": 0.5,  # Максимальная схожесть для last_name
+        },
     },
     {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",


### PR DESCRIPTION
Добавила в UserAttributeSimilarityValidator параметры last_name и first_name, поставила параметр max_similarity для каждого отдельно.
Почему-то значение 0.5 для last_name работает, как 0.7 для first_name. Если ставить 0.7 для last_name, то валидация с 7го символа не работает.